### PR TITLE
fix(parser): panic when processing a test run with no tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # ide and macOS finder files
 .idea/**
+.vscode/**
 **/.DS_Store
 
-# in general we ignore vscode settings, with some exceptions
-.vscode/**
+# exceptions for vs code
 !.vscode/spellright.dict
 
 # Binaries for programs and plugins
@@ -19,14 +19,11 @@
 # go coverage tool output
 *.out
 
-# workspace file
-go.work
-
 # dependency directories (uncomment the line below to include)
 # vendor/
 
 # test data (generated when parser_test.go is run)
-testdata/.json
+testdata/*.json
 
 # any binary or test/sample report (md) in the root
 test-report

--- a/parser.go
+++ b/parser.go
@@ -146,6 +146,10 @@ func (p *parser) recordFailure(line *line, rpt *testrun) {
 // recordSkip records a test skip, updating the test result and incrementing
 // the number of skipped tests in the testrun.
 func (p *parser) recordSkip(line *line, rpt *testrun) {
+	if line.Test == nil {
+		p.pkgs[line.Package].passed = false
+		return
+	}
 	p.tests[line.Package][*line.Test].result = trSkipped
 	rpt.numSkipped++
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,62 +14,103 @@ import (
 func generate() {
 	pwd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(pwd) }()
-
 	if err := os.Chdir("testdata"); err != nil {
-		fmt.Printf("cd testdata: %s\n", err)
+		fmt.Printf("chdir 'testdata': %s\n", err)
+		return
 	}
 
-	cmd := exec.Command("go", "test", "./...", "-json")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("%s: %s\n", cmd, err)
+	testPackages := func(dest string, pkgs ...string) {
+		cmd := exec.Command("go", append([]string{"test", "-json"}, pkgs...)...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("%s: %s\n", cmd, err)
+		}
+
+		file, err := os.Create(dest)
+		if err != nil {
+			fmt.Printf("create testdata/%s: %s\n", dest, err)
+		}
+		defer file.Close()
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("run '%s': %s\n", cmd, err)
+		}
+
+		if _, err := io.Copy(file, bytes.NewReader(output)); err != nil {
+			fmt.Printf("save output to 'testdata/%s': %s\n", dest, err)
+		}
 	}
 
-	file, err := os.Create(".json")
-	if err != nil {
-		fmt.Printf("create testdata/.json: %s\n", err)
-	}
-	defer file.Close()
-	if err := cmd.Run(); err != nil {
-		fmt.Printf("run '%s': %s\n", cmd, err)
-	}
-
-	if _, err := io.Copy(file, bytes.NewReader(output)); err != nil {
-		fmt.Printf("save output to 'testdata/.json': %s\n", err)
-	}
+	testPackages("packages.json", "./pkga", "./pkgb")
+	testPackages("no-test-files.json", "./no-test-files")
+	testPackages("no-code.json", "./no-code")
 }
 
 func TestParse(t *testing.T) {
 	// ARRANGE
 	generate()
 
-	report := &testrun{}
-	input, err := os.Open("./testdata/.json")
-	if err != nil {
-		t.Fatalf("error loading test data: %s", err)
-	}
-	defer input.Close()
-	p := parser{}
+	// ARRANGE
+	testcases := []struct {
+		scenario string
+		exec     func(t *testing.T)
+	}{
+		{scenario: "packages.json",
+			exec: func(t *testing.T) {
+				report := &testrun{}
+				input, err := os.Open("./testdata/packages.json")
+				if err != nil {
+					t.Fatalf("error loading test data: %s", err)
+				}
+				defer input.Close()
+				p := parser{}
 
-	// ACT
-	err = p.parse(input, report)
+				// ACT
+				err = p.parse(input, report)
 
-	// ASSERT
-	test.Error(t, err).IsNil()
-	test.That(t, len(report.packages)).Equals(2, "number of packages")
-	test.That(t, report.numTests).Equals(9, "number of tests")
-	test.That(t, report.numPassed).Equals(3, "tests passed")
-	test.That(t, report.numFailed).Equals(4, "tests failed")
-	test.That(t, report.numSkipped).Equals(2, "tests skipped")
+				// ASSERT
+				test.Error(t, err).IsNil()
+				test.That(t, len(report.packages)).Equals(2, "number of packages")
+				test.That(t, report.numTests).Equals(9, "number of tests")
+				test.That(t, report.numPassed).Equals(3, "tests passed")
+				test.That(t, report.numFailed).Equals(4, "tests failed")
+				test.That(t, report.numSkipped).Equals(2, "tests skipped")
 
-	test.Map(t, report.packages[1].tests[1].output).Equals(map[string][]string{
-		"pkgb_test.go:8": {
-			"this test fails",
-			"with four",
-			"lines of output",
-			"  the last is indented",
+				test.Map(t, report.packages[1].tests[1].output).Equals(map[string][]string{
+					"pkgb_test.go:8": {
+						"this test fails",
+						"with four",
+						"lines of output",
+						"  the last is indented",
+					},
+				})
+			},
 		},
-	})
-	// test.That(t, report.packages[1].tests[1].output["pkgb_test.go:12"][0]).Equals("TestFails")
-	// test.That(t, report.packages["github.com/blugnu/test-report/testdata/pkgb"]["TestFails"]).IsNotNil()
+		{scenario: "no-test-files.json",
+			exec: func(t *testing.T) {
+				report := &testrun{}
+				input, err := os.Open("./testdata/no-test-files.json")
+				if err != nil {
+					t.Fatalf("error loading test data: %s", err)
+				}
+				defer input.Close()
+				p := parser{}
+
+				// ACT
+				err = p.parse(input, report)
+
+				// ASSERT
+				test.Error(t, err).IsNil()
+				test.That(t, len(report.packages)).Equals(1, "number of packages")
+				test.That(t, report.numTests).Equals(0, "number of tests")
+				test.That(t, report.numPassed).Equals(0, "tests passed")
+				test.That(t, report.numFailed).Equals(0, "tests failed")
+				test.That(t, report.numSkipped).Equals(0, "tests skipped")
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.exec(t)
+		})
+	}
 }

--- a/testdata/no-code/.empty
+++ b/testdata/no-code/.empty
@@ -1,0 +1,2 @@
+this is a placeholder file to force git to track this folder which is otherwise empty
+for the purposes of this project

--- a/testdata/no-test-files/no-test-files.go
+++ b/testdata/no-test-files/no-test-files.go
@@ -1,0 +1,3 @@
+package notests
+
+const README = "this package contains no tests"


### PR DESCRIPTION
- fixed handling of "skip" output to cater for a test run with no tests;
- added parser test cases for a test run with no tests