### PR TITLE
handle non-test output (e.g. log.Println / fmt.Println / etc)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,0 @@
-name: module pipeline
-on: push
-jobs:
-  module-qa:
-    uses: blugnu/.reusable/.github/workflows/module.yml@master
-    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,6 @@
+name: release
+on: push
+jobs:
+  module-qa:
+    uses: blugnu/.reusable/.github/workflows/pipeline.module-release.yml@9f30317040dd8821a09f6c142738f427c1ca0eec
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,11 @@
 # go coverage tool output
 *.out
 
-# dependency directories (uncomment the line below to include)
-# vendor/
+# any binary or goreleaser builds
+dist/**
+test-report
 
 # test data (generated when parser_test.go is run)
 testdata/*.json
-
-# any binary or test/sample report (md) in the root
-test-report
+# any test/sample report (md) in the root
 test-report.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 1
+
+builds:
+  - goos:
+    - linux
+    - windows
+    - darwin
+  - goarch:
+    - amd64
+    - arm64
+  - ldflags:
+    - -s
+    - -w
+    - -X 'main.version=v{{ .Version }}'
+    - -X 'main.commit={{ .FullCommit }}'
+    - -X 'main.date={{ .CommitTimestamp }}'
+    - -X 'main.builtBy="goreleaser"'
+    - -X 'main.goVersion={{ .Env.GO_VERSION }}'
+  - mod_timestamp: "{{ .CommitTimestamp }}"

--- a/parser.go
+++ b/parser.go
@@ -85,8 +85,9 @@ func (p *parser) addPackage(line *line, rpt *testrun) {
 // from the line, setting the initial state of the test result to failed.
 func (p *parser) addTest(line *line, rpt *testrun) {
 	ti := &testinfo{
-		path:   *line.Test,
-		output: map[string][]string{},
+		path:        *line.Test,
+		output:      map[string][]string{},
+		packageName: line.Package,
 	}
 	p.tests[line.Package][*line.Test] = ti
 	pkg := p.pkgs[line.Package]
@@ -193,7 +194,10 @@ func (p *parser) processTestOutput(test *testinfo) {
 			continue
 		}
 		if test.result != trSkipped || !skiplog.MatchString(s) {
-			test.output[ref] = append(test.output[ref], s[8:len(s)-1])
+			if strings.HasPrefix(s, "        ") {
+				s = s[8 : len(s)-1]
+			}
+			test.output[ref] = append(test.output[ref], s)
 		}
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -76,11 +76,12 @@ func TestParse(t *testing.T) {
 				test.That(t, report.numSkipped).Equals(2, "tests skipped")
 
 				test.Map(t, report.packages[1].tests[1].output).Equals(map[string][]string{
-					"pkgb_test.go:8": {
+					"pkgb_test.go:11": {
 						"this test fails",
 						"with four",
 						"lines of output",
 						"  the last is indented",
+						"raw output is not indented (unlike test failure output)",
 					},
 				})
 			},

--- a/showVersion.go
+++ b/showVersion.go
@@ -2,13 +2,28 @@ package main
 
 import "fmt"
 
-// version of the program
-const version = "v0.1.0" //FUTURE: this should be set by the build system.
+// version information: set by the build process
+var (
+	commit    string
+	date      string
+	version   string
+	goVersion string
+	builtBy   string
+)
 
 // showVersion is a command that prints the version.
 type showVersion struct{}
 
 // run prints the version.
 func (showVersion) run(*opts) {
-	fmt.Printf("test-report %s\n", version)
+	if version == "" {
+		fmt.Println("test-report <unknown version>")
+		fmt.Println("(built from source)")
+		return
+	}
+	fmt.Printf("test-report v%s\n", version)
+	fmt.Println("commit:", commit)
+	fmt.Println("date:", date)
+	fmt.Println("built by:", builtBy)
+	fmt.Println("go version:", goVersion)
 }

--- a/showVersion_test.go
+++ b/showVersion_test.go
@@ -6,15 +6,62 @@ import (
 	"github.com/blugnu/test"
 )
 
+func using[T any](v *T, tv T) func() {
+	og := *v
+	*v = tv
+	return func() { *v = og }
+}
+
 func TestShowVersion(t *testing.T) {
 	// ARRANGE
-	cmd := &showVersion{}
+	testcases := []struct {
+		scenario string
+		exec     func(t *testing.T)
+	}{
+		{scenario: "version not set",
+			exec: func(t *testing.T) {
+				// ARRANGE
+				cmd := &showVersion{}
+				defer using(&version, "")()
 
-	// ACT
-	stdout, _ := test.CaptureOutput(t, func() {
-		cmd.run(nil)
-	})
+				// ACT
+				stdout, _ := test.CaptureOutput(t, func() {
+					cmd.run(nil)
+				})
 
-	// ASSERT
-	stdout.Equals([]string{"test-report v0.1.0"})
+				// ASSERT
+				stdout.Equals([]string{"test-report <unknown version>", "(built from source)"})
+			},
+		},
+		{scenario: "version set",
+			exec: func(t *testing.T) {
+				// ARRANGE
+				cmd := &showVersion{}
+				defer using(&version, "1.0.0")()
+				defer using(&commit, "commit")()
+				defer using(&date, "date")()
+				defer using(&builtBy, "builtBy")()
+				defer using(&goVersion, "goVersion")()
+
+				// ACT
+				stdout, _ := test.CaptureOutput(t, func() {
+					cmd.run(nil)
+				})
+
+				// ASSERT
+				stdout.Equals([]string{
+					"test-report v1.0.0",
+					"commit: commit",
+					"date: date",
+					"built by: builtBy",
+					"go version: goVersion",
+				})
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			tc.exec(t)
+		})
+	}
 }

--- a/testdata/pkgb/pkgb_test.go
+++ b/testdata/pkgb/pkgb_test.go
@@ -1,11 +1,15 @@
 package pkgb
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestPasses(t *testing.T) {}
 
 func TestFails(t *testing.T) {
 	t.Error("this test fails\nwith four\nlines of output\n  the last is indented")
+	fmt.Print("raw output is not indented (unlike test failure output)")
 }
 
 func TestSkipped(t *testing.T) {

--- a/testrun.go
+++ b/testrun.go
@@ -21,9 +21,10 @@ const (
 
 // testinfo contains information about a single test.
 type testinfo struct {
-	path    string        // the path to (name of) the test
-	result  testResult    // the result of the test
-	elapsed time.Duration // the time taken to run the test (if recorded)
+	path        string        // the path to (name of) the test
+	result      testResult    // the result of the test
+	elapsed     time.Duration // the time taken to run the test (if recorded)
+	packageName string        // the name of the package containing the test
 
 	// the output of the test; during parsing all output is added to
 	// a "raw" item in the map.  Once all output has been parsed, the "raw"


### PR DESCRIPTION
fixes #6

also updated workflow to use `.reusable` with go release support and configuration to produce binaries attached to new releases